### PR TITLE
Add Android instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # react-native-smooch
 React Native wrapper for Smooch.io. Based off of [smooch-cordova](https://github.com/smooch/smooch-cordova)
 
+This React Native module was built and tested with version 0.18 of React Native. Since React Native is not mature yet, there might be some breaking changes which will break our module. Therefore, if you find a problem, please open an issue.
+
 At the moment, this wrapper only covers the most commonly used features of the Smooch SDK. We encourage you to add to this wrapper or make any feature requests you need. Pull requests most definitely welcome!
 
 Please hit up [@gozmike](https://twitter.com/gozmike) with any questions or [contact Smooch](mailto:help@smooch.io).
@@ -10,15 +12,21 @@ Installing Smooch on React Native
 
 First, make sure you've [signed up for Smooch](https://app.smooch.io/signup)
 
-Next, grab this React component with `npm install react-native-smooch`
+If you don't already have a React Native application setup, follow the instructions [here](https://facebook.github.io/react-native/docs/getting-started.html) to create one.
+
+Next, grab this React Native module with `npm install react-native-smooch`
 
 ## iOS
 
- * Navigate to the .xcodeproj in your React Native project's directory and follow [these steps](http://docs.smooch.io/ios/#adding-smooch-to-your-app) for adding the Smooch binary distribution to your project with CocoaPods.
+ * Navigate to your React Native project's `ios` directory and follow [these steps](http://docs.smooch.io/ios/#adding-smooch-to-your-app) for adding the Smooch binary distribution to your project with CocoaPods.
 
  * Open your project's .xcworkspace file in XCode and initialize Smooch with your app token inside of applicationDidFinishLaunchingWithOptions.
 
 ```
+#import <Smooch/Smooch.h>
+
+...
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Initialize Smooch - these instructions are also available on [app.smooch.io](https://app.smooch.io)
     [Smooch initWithSettings:
@@ -32,7 +40,58 @@ You're now ready to start interacting with Smooch in your React Native app.
 
 ## Android
 
-Coming soon!
+* Open the `/android` directory of your React Native project in Android Studio.
+* Open the `/android/build.gradle` file. Make sure that `jcenter()` is listed in the repositories.
+```
+buildscript {
+    repositories {
+        jcenter()
+    }
+    ...
+```
+
+* Open the `/android/app/build.gradle` file and add Smooch to the dependencies.
+```
+dependencies {
+    ...
+    compile 'io.smooch:core:latest.release'
+    compile 'io.smooch:ui:latest.release'
+}
+```
+
+* Create an Application class for the React project. Add `Smooch.init` in the `onCreate` method.
+```
+public class ReactNativeApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Smooch.init(this, "<your-smooch-app-token>");
+    }
+}
+```
+
+* In the `AndroidManifest.xml` file, make sure to reference the application class you just created (replace `<package-name>` with your React Application's package name).
+
+```
+<application
+  android:name="<package-name>.ReactNativeApplication"
+  ...
+  >
+```
+
+* Copy the `SmoochManager.java` and `SmoochPackage.java` files from `node_modules/react-native-smooch/android` into your the Android project.
+* In the `MainActivity.java` file, add `new SmoochPackage()` to the `getPackages()` method.
+
+```
+ @Override
+ protected List<ReactPackage> getPackages() {
+   return Arrays.asList(
+     new MainReactPackage(), new SmoochPackage());
+ }
+ ```
+
+You're now ready to start interacting with Smooch in your React Native app.
 
 Using Smooch in your React Native App
 =====================================
@@ -75,4 +134,3 @@ Smooch.track("User tapped");
 Learn more about the functions we've wrapped by checking out SmoochClient.js in the "lib" directory.
 
 ![](https://media.giphy.com/media/h9KtiB6DgiS2s/giphy.gif)
-

--- a/android/SmoochManager.java
+++ b/android/SmoochManager.java
@@ -1,0 +1,93 @@
+package com.awesomeproject;
+
+import android.util.Log;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableType;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.smooch.core.User;
+import io.smooch.ui.ConversationActivity;
+import io.smooch.core.Smooch;
+
+/**
+ * Created by mario on 2016-01-18.
+ */
+
+public class SmoochManager extends ReactContextBaseJavaModule {
+    @Override
+    public String getName() {
+        return "SmoochManager";
+    }
+
+    public SmoochManager(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @ReactMethod
+    public void login(String userId, String jwt) {
+        Smooch.login(userId, jwt);
+    }
+
+    @ReactMethod
+    public void show() {
+        ConversationActivity.show(getCurrentActivity());
+    }
+
+    @ReactMethod
+    public void track(String event) {
+        Smooch.track(event);
+    }
+
+    @ReactMethod
+    public void setFirstName(String firstName) {
+        User.getCurrentUser().setFirstName(firstName);
+    }
+
+    @ReactMethod
+    public void setLastName(String lastName) {
+        User.getCurrentUser().setLastName(lastName);
+    }
+
+    @ReactMethod
+    public void setEmail(String email) {
+        User.getCurrentUser().setEmail(email);
+    }
+
+    @ReactMethod
+    public void setUserProperties(ReadableMap properties) {
+        User.getCurrentUser().addProperties(getUserProperties(properties));
+    }
+
+    private Map<String, Object> getUserProperties(ReadableMap properties) {
+        ReadableMapKeySetIterator iterator = properties.keySetIterator();
+        Map<String, Object> userProperties = new HashMap<>();
+
+        while(iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            ReadableType type = properties.getType(key);
+            if (type == ReadableType.Boolean) {
+                userProperties.put(key, properties.getBoolean(key));
+            } else if (type == ReadableType.Number) {
+                userProperties.put(key, properties.getDouble(key));
+            } else if (type == ReadableType.String) {
+                userProperties.put(key, properties.getString(key));
+            }
+        }
+
+        return userProperties;
+    }
+
+
+}

--- a/android/SmoochPackage.java
+++ b/android/SmoochPackage.java
@@ -1,0 +1,35 @@
+package com.awesomeproject;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by mario on 2016-01-18.
+ */
+public class SmoochPackage implements ReactPackage {
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new SmoochManager(reactContext));
+
+        return modules;
+    }
+
+    @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return new ArrayList<>();
+    }
+}

--- a/ios/SmoochManager.m
+++ b/ios/SmoochManager.m
@@ -5,76 +5,59 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(show:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(show) {
   NSLog(@"Smooch Show");
-  
-dispatch_async(dispatch_get_main_queue(), ^{
+
+  dispatch_async(dispatch_get_main_queue(), ^{
     [Smooch show];
   });
-
-  callback(@[[NSNull null]]);
 };
 
-RCT_EXPORT_METHOD(login:(NSString*)userId jwt:(NSString*)jwt callback:(RCTResponseSenderBlock)callback) {
-  NSLog(@"Smooch Show");
-  
-dispatch_async(dispatch_get_main_queue(), ^{
+RCT_EXPORT_METHOD(login:(NSString*)userId jwt:(NSString*)jwt) {
+  NSLog(@"Smooch Login");
+
+  dispatch_async(dispatch_get_main_queue(), ^{
     [Smooch login:userId jwt:jwt];
   });
-
-  callback(@[[NSNull null]]);
 };
 
-RCT_EXPORT_METHOD(logout:(RCTResponseSenderBlock)callback) {
-  NSLog(@"Smooch Show");
-  
+RCT_EXPORT_METHOD(logout) {
+  NSLog(@"Smooch Logout");
+
 dispatch_async(dispatch_get_main_queue(), ^{
     [Smooch logout];
   });
-
-  callback(@[[NSNull null]]);
 };
 
 
-RCT_EXPORT_METHOD(setUserProperties:(NSDictionary*)options callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(setUserProperties:(NSDictionary*)options) {
   NSLog(@"Smooch setUserProperties with %@", options);
-  NSDictionary* attributes = options;
-  
+
   [[SKTUser currentUser] addProperties:options];
-
-  callback(@[[NSNull null]]);
 };
 
-RCT_EXPORT_METHOD(track:(NSString*)eventName callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(track:(NSString*)eventName) {
   NSLog(@"Smooch track with %@", eventName);
-  
+
   [Smooch track:eventName];
-
-  callback(@[[NSNull null]]);
 };
 
-RCT_EXPORT_METHOD(setFirstName:(NSString*)firstName callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(setFirstName:(NSString*)firstName) {
   NSLog(@"Smooch setFirstName");
-  
+
   [SKTUser currentUser].firstName = firstName;
-  
-  callback(@[[NSNull null]]);
 };
 
-RCT_EXPORT_METHOD(setLastName:(NSString*)lastName callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(setLastName:(NSString*)lastName) {
   NSLog(@"Smooch setLastName");
-  
+
   [SKTUser currentUser].lastName = lastName;
-  
-  callback(@[[NSNull null]]);
 };
 
-RCT_EXPORT_METHOD(setEmail:(NSString*)email callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(setEmail:(NSString*)email) {
   NSLog(@"Smooch setEmail");
-  
+
   [SKTUser currentUser].email = email;
-  
-  callback(@[[NSNull null]]);
 };
 
 @end

--- a/lib/SmoochClient.js
+++ b/lib/SmoochClient.js
@@ -1,112 +1,14 @@
 'use strict';
 
 var React = require('react-native');
-var {
-	NativeModules
-} = React;
+var { NativeModules } = React;
 
 let SmoochManager = NativeModules.SmoochManager;
 
-/**
- * @class SmoochClient
- */
+module.exports = Object.assign({}, SmoochManager, {
+    login: function login(userId, jwt) {
+    	jwt = jwt || '';
 
-class SmoochClient {
-	show() {
-		return new Promise((resolve, reject) => {
-			SmoochManager.show(function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}
-
-	login(userId, jwt) {
-		return new Promise((resolve, reject) => {
-			SmoochManager.login(userId, jwt, function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}
-
-	logout() {
-		return new Promise((resolve, reject) => {
-			SmoochManager.logout(function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}	
-
-	setUserProperties(properties) {
-		return new Promise((resolve, reject) => {
-			SmoochManager.setUserProperties(properties, function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}
-
-	track(eventName) {
-		return new Promise((resolve, reject) => {
-			SmoochManager.track(eventName, function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}
-
-	setFirstName(firstName) {
-		return new Promise((resolve, reject) => {
-			SmoochManager.setFirstName(firstName, function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}
-
-	setLastName(lastName) {
-		return new Promise((resolve, reject) => {
-			SmoochManager.setLastName(lastName, function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}
-
-	setEmail(email) {
-		return new Promise((resolve, reject) => {
-			SmoochManager.setEmail(email, function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}	
-}
-
-module.exports = new SmoochClient();
+    	return SmoochManager.login(userId, jwt);
+    }
+});


### PR DESCRIPTION
@gozman @mspensieri @jugarrit @dannytranlx @jpjoyal 

Couple of changes:
- No longer return promises from our React Native module since it doesn't make sense to do so currently (our API's function in iOS and Android don't accept callbacks).
- Added `SmoochManager.java` and `SmoochPackage.java` for bridging with our native Android package.
- Added the instructions for Android to the README.
- Some small modifications to the iOS instructions.
