### PR TITLE
Add podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ Next, grab this React Native module with `npm install react-native-smooch`
 
 ## iOS
 
- * Navigate to your React Native project's `ios` directory and follow [these steps](http://docs.smooch.io/ios/#adding-smooch-to-your-app) for adding the Smooch binary distribution to your project with CocoaPods.
+ * Add react-native-smooch to your Podfile
+
+```
+pod 'react-native-smooch',
+    :path => '../node_modules/react-native-smooch'
+```
+
+ * Install the pod
+
+   `pod install`
 
  * Open your project's .xcworkspace file in XCode and initialize Smooch with your app token inside of applicationDidFinishLaunchingWithOptions.
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Next, grab this React Native module with `npm install react-native-smooch`
 
 ## iOS
 
- * Add react-native-smooch to your Podfile
+ * Add react-native-smooch to your `Podfile`:
 
 ```
+...
 pod 'react-native-smooch',
     :path => '../node_modules/react-native-smooch'
+...
 ```
 
- * Install the pod
-
-   `pod install`
+ * Install it: `pod install`
 
  * Open your project's .xcworkspace file in XCode and initialize Smooch with your app token inside of applicationDidFinishLaunchingWithOptions.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Next, grab this React Native module with `npm install react-native-smooch`
 
 ## iOS
 
- * Add react-native-smooch to your `Podfile`:
+ * With CococaPods:
+
+   Add the react-native-smooch Pod in your `Podfile`:
 
 ```
 ...
@@ -27,7 +29,9 @@ pod 'react-native-smooch',
 ...
 ```
 
- * Install it: `pod install`
+   Install it by running `pod install`.
+
+ * Without CocoaPods, navigate to your React Native project's `ios` directory and follow [these steps](http://docs.smooch.io/ios/#adding-smooch-to-your-app).
 
  * Open your project's .xcworkspace file in XCode and initialize Smooch with your app token inside of applicationDidFinishLaunchingWithOptions.
 

--- a/react-native-smooch.podspec
+++ b/react-native-smooch.podspec
@@ -8,7 +8,6 @@ Pod::Spec.new do |s|
   s.homepage     = 'n/a'
   s.source       = { :git => "https://github.com/smooch/react-native-smooch" }
   s.source_files = 'ios/*'
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "8.0"
   s.dependency 'Smooch', '~> 4.0'
-  s.dependency 'React'
 end

--- a/react-native-smooch.podspec
+++ b/react-native-smooch.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name             = "react-native-smooch"
+  s.version          = "0.1.1"
+  s.summary          = "A React Native client for smooch.io"
+  s.requires_arc = true
+  s.author       = { "Mike Gozzo" => "gozman@users.noreply.github.com" }
+  s.license      = 'MIT'
+  s.homepage     = 'n/a'
+  s.source       = { :git => "https://github.com/smooch/react-native-smooch" }
+  s.source_files = 'ios/*'
+  s.platform     = :ios, "7.0"
+  s.dependency 'Smooch', '~> 4.0'
+  s.dependency 'React'
+end


### PR DESCRIPTION
Removes the need to install/link 'Smooch' pod separately when using CocoaPods.
