### PR TITLE
update android build tools to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ protected List<ReactPackage> getPackages() {
 ```
 
 * Add `Smooch.init` to the `onCreate` method of your `Application` class.
+
 ```java
+import io.smooch.core.Smooch;
+import com.facebook.soloader.SoLoader;
+
 public class MainApplication extends Application implements ReactApplication {
     ...
     @Override

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,12 +17,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Fixes #21 

I'm currently running..

react-native: `0.42.0`
react-native-smooch: `0.2.2`

Everything on iOS works great when compiling; however on Android I continue to get this error:
```
/Users/bob/projects/test/node_modules/react-native-smooch/android/build/intermediates/res/merged/release/values-v24/values-v24.xml:3: AAPT: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Borderless.Colored'.
    
/Users/bob/projects/test/node_modules/react-native-smooch/android/build/intermediates/res/merged/release/values-v24/values-v24.xml:4: AAPT: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Colored'.
    
/Users/bob/projects/test/node_modules/react-native-smooch/android/build/intermediates/res/merged/release/values-v24/values-v24.xml:3: error: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Borderless.Colored'.

/Users/bob/projects/test/node_modules/react-native-smooch/android/build/intermediates/res/merged/release/values-v24/values-v24.xml:4: error: Error retrieving parent for item: No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Colored'.
```

I made sure that all my versions were correct on my dependencies and even tried updating them to build tools version `25.0.0` and compileSDKVersion `25` and I continued to get this error. After running the build with `--stacktrace` flag I was able to find that it was because the android library for `react-native-smooch` was trying to use `23.0.1` to build and therefore were missing values for api version `24`. Updating the build versions to this seems to solve the issue.

I also noticed that on the demo app for `smooch-android` is set to `24.0.1`. https://github.com/smooch/smooch-android/blob/master/demo/gradle/app/build.gradle#L5
