### PR TITLE
Exported smooch init method to RN

### DIFF
--- a/ios/RCTSmooch/RCTSmooch.m
+++ b/ios/RCTSmooch/RCTSmooch.m
@@ -5,6 +5,13 @@
 
 RCT_EXPORT_MODULE();
 
+RCT_EXPORT_METHOD(init:(NSString*)appToken:(RCTResponseSenderBlock)callback) {
+  NSLog(@"Init Smooch");
+
+  [Smooch initWithSettings: [SKTSettings settingsWithAppToken:appToken]];
+  callback(@[]);
+};
+
 RCT_EXPORT_METHOD(show) {
   NSLog(@"Smooch Show");
 


### PR DESCRIPTION
This PR (ios) aims at exposing an init method directly from RN. Thus, RN users can avoid editing the AppDelegate.m file. Eventually, it is easier to maintain config for different env (CI etc...).