### PR TITLE
Fix completionhandler and podspec

### DIFF
--- a/ios/RCTSmooch/RCTSmooch.m
+++ b/ios/RCTSmooch/RCTSmooch.m
@@ -19,7 +19,10 @@ RCT_EXPORT_METHOD(login:(NSString*)userId jwt:(NSString*)jwt resolver:(RCTPromis
   dispatch_async(dispatch_get_main_queue(), ^{
       [Smooch login:userId jwt:jwt completionHandler:^(NSError * _Nullable error, NSDictionary * _Nullable userInfo) {
           if (error) {
-              reject(nil, nil, error);
+              reject(
+                 userInfo[SKTErrorCodeIdentifier],
+                 userInfo[SKTErrorDescriptionIdentifier],
+                 error);
           }
           else {
               resolve(userInfo);
@@ -34,7 +37,10 @@ RCT_EXPORT_METHOD(logoutWithCompletionHandler:(RCTPromiseResolveBlock)resolve re
   dispatch_async(dispatch_get_main_queue(), ^{
       [Smooch logoutWithCompletionHandler:^(NSError * _Nullable error, NSDictionary * _Nullable userInfo) {
           if (error) {
-              reject(nil, nil, error);
+              reject(
+                     userInfo[SKTErrorCodeIdentifier],
+                     userInfo[SKTErrorDescriptionIdentifier],
+                     error);
           }
           else {
               resolve(userInfo);

--- a/ios/RCTSmooch/RCTSmooch.m
+++ b/ios/RCTSmooch/RCTSmooch.m
@@ -13,19 +13,33 @@ RCT_EXPORT_METHOD(show) {
   });
 };
 
-RCT_EXPORT_METHOD(login:(NSString*)userId jwt:(NSString*)jwt completionHandler:(nullable void(^)(NSError * _Nullable error, NSDictionary * _Nullable userInfo))handler) {
+RCT_EXPORT_METHOD(login:(NSString*)userId jwt:(NSString*)jwt resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   NSLog(@"Smooch Login");
 
   dispatch_async(dispatch_get_main_queue(), ^{
-      [Smooch login:userId jwt:jwt completionHandler:handler];
+      [Smooch login:userId jwt:jwt completionHandler:^(NSError * _Nullable error, NSDictionary * _Nullable userInfo) {
+          if (error) {
+              reject(nil, nil, error);
+          }
+          else {
+              resolve(userInfo);
+          }
+      }];
   });
 };
 
-RCT_EXPORT_METHOD(logoutWithCompletionHandler:(nullable void ( ^ ) ( NSError *_Nullable error , NSDictionary *_Nullable userInfo ))handler) {
+RCT_EXPORT_METHOD(logoutWithCompletionHandler:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   NSLog(@"Smooch Logout");
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    [Smooch logoutWithCompletionHandler:handler];
+      [Smooch logoutWithCompletionHandler:^(NSError * _Nullable error, NSDictionary * _Nullable userInfo) {
+          if (error) {
+              reject(nil, nil, error);
+          }
+          else {
+              resolve(userInfo);
+          }
+      }];
   });
 };
 

--- a/ios/RCTSmooch/RCTSmooch.m
+++ b/ios/RCTSmooch/RCTSmooch.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(login:(NSString*)userId jwt:(NSString*)jwt resolver:(RCTPromis
   });
 };
 
-RCT_EXPORT_METHOD(logoutWithCompletionHandler:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(logout:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   NSLog(@"Smooch Logout");
 
   dispatch_async(dispatch_get_main_queue(), ^{

--- a/react-native-smooch.podspec
+++ b/react-native-smooch.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.homepage     = 'n/a'
   s.source       = { :git => "https://github.com/smooch/react-native-smooch" }
-  s.source_files = 'ios/*'
+  s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
   s.dependency 'Smooch', '~> 6.0'
   s.dependency 'React'


### PR DESCRIPTION
`login` / `logout` are not working due to the `completionHandler` argument. This PR now returns a promise which will resolve or reject with the error information. I took the liberty of renaming `logoutWithCompletionHandler` to just `logout` (completion handler is an implementation detail). The methods can be just called and ignore the promise result as well, like before. 

Something worrying is that under certain conditions I can see warnings in XCode console, such as:
```
<SMOOCH::WARNING> User X is already logged in. Ignoring!
```
```
<SMOOCH::WARNING> Login called with nil or empty jwt. Ignoring!
```
In these cases the promise will neither resolve nor reject because completionHandler isn't being called. Not calling the completionHandler seems like a bad idea to me but that problem belongs to the Smooch iOS library. However, not resolving a promise is really bad because it would break code that waits for this promise. Not sure what to do about that? Maybe it's better I just set `completionHandler` to `nil` and pretend nothing ever fails? That would be sad though because the whole point was to be able to detect errors...

The podspec was also broken due to paths which has also been fixed here.

Fixes #46 