### PR TITLE
bump to latest smooch

### DIFF
--- a/react-native-smooch.podspec
+++ b/react-native-smooch.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/smooch/react-native-smooch" }
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
-  s.dependency 'Smooch', '~> 6.0'
+  s.dependency 'Smooch', '~> 7.1.2'
   s.dependency 'React'
 end


### PR DESCRIPTION
as title.

If there's a better way to force a version of smooch without having to update the wrapper, would be interested too! I didn't bump package versions as assumed that was something you would like to do.

Thanks for attention. 